### PR TITLE
Add post fields for hierarchy and ordering

### DIFF
--- a/models/post.php
+++ b/models/post.php
@@ -141,7 +141,7 @@ class JSON_API_Post {
     $this->set_value('excerpt', apply_filters('the_excerpt', get_the_excerpt()));
     $this->set_value('order', $wp_post->menu_order);
     $this->set_value('parent', $wp_post->post_parent);
-    $this->set_value('date', get_the_time('Y-m-d\TH:i:s\Z'));    
+    $this->set_value('date', get_the_time($date_format));
     $this->set_value('modified', date($date_format, strtotime($wp_post->post_modified)));
     $this->set_categories_value();
     $this->set_tags_value();


### PR DESCRIPTION
The API will now show the parent (if any) and the ordering of the post (again, if there is any ordering).
