### PR TITLE
Unserialize custom fields

### DIFF
--- a/json-api.php
+++ b/json-api.php
@@ -3,7 +3,7 @@
 Plugin Name: WordPress JSON API
 Plugin URI: https://github.com/cfpb/wp-json-api
 Description: A RESTful API for WordPress
-Version: 1.1.4
+Version: 1.1.5
 Author: Dan Phiffer, Greg Boone
 */
 

--- a/models/post.php
+++ b/models/post.php
@@ -272,12 +272,17 @@ class JSON_API_Post {
         $keys = explode(',', $json_api->query->custom_fields);
       }
       foreach ($wp_custom_fields as $key => $value) {
+        if ( sizeof( $wp_custom_fields[$key] ) > 1 ) {
+          $field = $wp_custom_fields[$key];
+        } else {
+          $field = $wp_custom_fields[$key][0];
+        }
         if ($json_api->query->custom_fields) {
           if (in_array($key, $keys)) {
-            $this->custom_fields->$key = $wp_custom_fields[$key];
+            $this->custom_fields->$key = maybe_unserialize( $field );
           }
         } else if (substr($key, 0, 1) != '_') {
-          $this->custom_fields->$key = $wp_custom_fields[$key];
+          $this->custom_fields->$key = maybe_unserialize( $field );
         }
       }
     } else {

--- a/singletons/query.php
+++ b/singletons/query.php
@@ -1,10 +1,11 @@
 <?php
+use \DateTime;
 
 class JSON_API_Query {
   
   // Default values
   protected $defaults = array(
-    'date_format' => 'Y-m-d H:i:s',
+    'date_format' => Datetime::ISO8601,
     'read_more' => 'Read more'
   );
   


### PR DESCRIPTION
Currently, custom fields are being output in json literally from the Wordpress database. In Wordpress, arrays are serialized into a string and then saved in the database so your JSON output is serialized. No good. We want a nice json object. This accomplishes that in this case.

## Additions

- `unserialize_custom_field()` that accepts one parameter. It is used to unserialize potentially serialized given fields.

## Changes

- Custom fields are assigned by calling the added method instead of directly copying the field from the Wordpress database.

## Testing

- https://github.com/cfpb/wp-json-api#6-unit-tests

## Review

- @dpford 
- @willbarton 
- @Scotchester 

## Notes

- This is added in conjunction with a [PR on the cms-toolkit](https://github.com/cfpb/cms-toolkit/pull/55)