### PR TITLE
Add relative url to json output

### DIFF
--- a/json-api.php
+++ b/json-api.php
@@ -3,7 +3,7 @@
 Plugin Name: WordPress JSON API
 Plugin URI: https://github.com/cfpb/wp-json-api
 Description: A RESTful API for WordPress
-Version: 1.1.3
+Version: 1.1.4
 Author: Dan Phiffer, Greg Boone
 */
 

--- a/models/post.php
+++ b/models/post.php
@@ -128,11 +128,13 @@ class JSON_API_Post {
   function import_wp_object($wp_post) {
     global $json_api, $post;
     $date_format = $json_api->query->date_format;
+    $relative_url = parse_url( get_permalink( get_the_ID() ) );
     $this->id = (int) $wp_post->ID;
     setup_postdata($wp_post);
     $this->set_value('type', $wp_post->post_type);
     $this->set_value('slug', $wp_post->post_name);
     $this->set_value('url', get_permalink($this->id));
+    $this->set_value('relative_url', $relative_url['path']);
     $this->set_value('status', $wp_post->post_status);
     $this->set_value('title', get_the_title($this->id));
     $this->set_value('title_plain', strip_tags(@$this->title));


### PR DESCRIPTION
Frontends are sick and tired of having to specify ID's with numbers that change across Wordpress installs. This changes that. There's a `relative_path` field that is outputted to JSON that can be used to uniquely identify posts (most helpful in the case of pages).

@dpford @willbarton @Scotchester 